### PR TITLE
feat: add paid show window to account ux

### DIFF
--- a/app/band/account/page.test.tsx
+++ b/app/band/account/page.test.tsx
@@ -40,11 +40,19 @@ vi.mock('@/components/band-access-form', () => ({
 function buildSupabaseClient() {
   return {
     from(table: string) {
-      if (table === 'band_profiles' || table === 'billing_accounts') {
+      if (table === 'band_profiles' || table === 'billing_accounts' || table === 'billing_show_windows') {
+        const query = {
+          maybeSingle: async () => createQueryMock(table),
+          order: vi.fn(() => ({
+            limit: vi.fn(async () => createQueryMock(table)),
+          })),
+        }
+
         return {
           select: vi.fn(() => ({
-            eq: vi.fn(() => ({
-              maybeSingle: async () => createQueryMock(table),
+            eq: vi.fn(() => query),
+            order: vi.fn(() => ({
+              limit: vi.fn(async () => createQueryMock(table)),
             })),
           })),
         }
@@ -96,6 +104,21 @@ beforeEach(() => {
       }
     }
 
+    if (table === 'billing_show_windows') {
+      return {
+        data: [
+          {
+            event_id: 'event-1',
+            started_at: '2026-04-05T14:00:00.000Z',
+            expires_at: '2026-04-06T14:00:00.000Z',
+            undo_grace_until: '2026-04-05T14:05:00.000Z',
+            restart_count: 1,
+          },
+        ],
+        error: null,
+      }
+    }
+
     return { data: null, error: null }
   })
 })
@@ -122,6 +145,9 @@ describe('BandAccountPage', () => {
     expect(screen.getAllByText(/hosted checkout is unavailable in this environment yet/i).length).toBeGreaterThanOrEqual(1)
     expect(screen.getAllByText(/2 of 3 remaining/i).length).toBeGreaterThanOrEqual(2)
     expect(screen.getByRole('checkbox', { name: /i agree to the terms of service before starting subscription checkout/i })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /current paid show status/i })).toBeInTheDocument()
+    expect(screen.getByText(/event-1/i)).toBeInTheDocument()
+    expect(screen.getByText(/undo grace is active until/i)).toBeInTheDocument()
   })
 
   it('shows the free state when no billing account exists', async () => {
@@ -135,6 +161,10 @@ describe('BandAccountPage', () => {
           data: null,
           error: null,
         }
+      }
+
+      if (table === 'billing_show_windows') {
+        return { data: [], error: null }
       }
 
       return { data: null, error: null }
@@ -167,6 +197,10 @@ describe('BandAccountPage', () => {
           },
           error: null,
         }
+      }
+
+      if (table === 'billing_show_windows') {
+        return { data: [], error: null }
       }
 
       return { data: null, error: null }

--- a/app/band/account/page.tsx
+++ b/app/band/account/page.tsx
@@ -86,6 +86,7 @@ function AccountForm({
   username,
   bandName,
   bandProfile,
+  currentPaidWindow,
   tidalClientId,
   hasTidalClientSecret,
   subscriptionControlState,
@@ -104,6 +105,13 @@ function AccountForm({
     cashapp_url: string | null
     custom_message: string | null
     logo_url?: string | null
+  } | null
+  currentPaidWindow: {
+    event_id: string
+    started_at: string
+    expires_at: string
+    undo_grace_until: string | null
+    restart_count: number | null
   } | null
   tidalClientId: string | null
   hasTidalClientSecret: boolean
@@ -267,6 +275,43 @@ function AccountForm({
         <section className="rounded-3xl border border-white/10 bg-white/5 p-6">
           <div className="flex flex-wrap items-start justify-between gap-4">
             <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.28em] text-cyan-300">Active access window</p>
+              <h2 className="mt-2 text-2xl font-semibold text-white">Current paid show status</h2>
+              <p className="mt-2 max-w-2xl text-slate-300">This shows the live 24-hour access window for the most recent paid show, including any undo grace period.</p>
+            </div>
+          </div>
+          {currentPaidWindow ? (
+            <div className="mt-4 grid gap-3 md:grid-cols-4">
+              <div className="rounded-2xl border border-white/10 bg-slate-950/50 px-4 py-3 text-sm text-slate-300">
+                <p className="font-semibold text-white">Show ID</p>
+                <p className="mt-1 break-all">{currentPaidWindow.event_id}</p>
+              </div>
+              <div className="rounded-2xl border border-white/10 bg-slate-950/50 px-4 py-3 text-sm text-slate-300">
+                <p className="font-semibold text-white">Started</p>
+                <p className="mt-1">{currentPaidWindow.started_at}</p>
+              </div>
+              <div className="rounded-2xl border border-white/10 bg-slate-950/50 px-4 py-3 text-sm text-slate-300">
+                <p className="font-semibold text-white">Expires</p>
+                <p className="mt-1">{currentPaidWindow.expires_at}</p>
+              </div>
+              <div className="rounded-2xl border border-white/10 bg-slate-950/50 px-4 py-3 text-sm text-slate-300">
+                <p className="font-semibold text-white">Restarts</p>
+                <p className="mt-1">{currentPaidWindow.restart_count ?? 0}</p>
+              </div>
+            </div>
+          ) : (
+            <p className="mt-4 rounded-2xl border border-white/10 bg-slate-950/50 px-4 py-3 text-sm text-slate-300">No active paid show window is on file yet. Start a show to create one.</p>
+          )}
+          {currentPaidWindow?.undo_grace_until ? (
+            <p className="mt-4 rounded-2xl border border-cyan-400/20 bg-cyan-400/10 px-4 py-3 text-sm text-cyan-100">
+              Undo grace is active until {currentPaidWindow.undo_grace_until}.
+            </p>
+          ) : null}
+        </section>
+
+        <section className="rounded-3xl border border-white/10 bg-white/5 p-6">
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div>
               <p className="text-xs font-semibold uppercase tracking-[0.28em] text-cyan-300">Billing portal</p>
               <h2 className="mt-2 text-2xl font-semibold text-white">Payment methods and invoices</h2>
               <p className="mt-2 max-w-2xl text-slate-300">{billingStatusMessage}</p>
@@ -412,12 +457,19 @@ export default async function BandAccountPage({ searchParams }: { searchParams?:
       .select('status, payment_provider, payment_subscription_id, free_shows_allocated, free_shows_used')
       .eq('band_id', liveAccess.bandId)
       .maybeSingle()
+    const { data: currentPaidWindows } = await serviceSupabase
+      .from('billing_show_windows')
+      .select('event_id, started_at, expires_at, undo_grace_until, restart_count')
+      .eq('band_id', liveAccess.bandId)
+      .order('started_at', { ascending: false })
+      .limit(1)
 
     return (
       <AccountForm
         username={liveAccess.username}
         bandName={liveAccess.bandName}
         bandProfile={bandProfile}
+        currentPaidWindow={(currentPaidWindows ?? [])[0] ?? null}
         tidalClientId={tidalSettings?.tidal_client_id ?? null}
         hasTidalClientSecret={Boolean(tidalSettings?.tidal_client_secret)}
         subscriptionControlState={resolveSubscriptionControlState(billingAccount)}
@@ -440,12 +492,19 @@ export default async function BandAccountPage({ searchParams }: { searchParams?:
         .select('status, payment_provider, payment_subscription_id, free_shows_allocated, free_shows_used')
         .eq('band_id', testSession.activeBandId)
         .maybeSingle()
+      const { data: currentPaidWindows } = await serviceSupabase
+        .from('billing_show_windows')
+        .select('event_id, started_at, expires_at, undo_grace_until, restart_count')
+        .eq('band_id', testSession.activeBandId)
+        .order('started_at', { ascending: false })
+        .limit(1)
 
       return (
         <AccountForm
           username={current.username}
           bandName={current.band_name ?? bandCopy.accountPage.bandFallbackName}
           bandProfile={null}
+          currentPaidWindow={(currentPaidWindows ?? [])[0] ?? null}
           tidalClientId={tidalSettings?.tidal_client_id ?? null}
           hasTidalClientSecret={Boolean(tidalSettings?.tidal_client_secret)}
           subscriptionControlState={resolveSubscriptionControlState(billingAccount)}


### PR DESCRIPTION
## Summary

The band account page now shows the current paid show access window alongside plan status and credits, so users can see what is active and when it expires without digging through other screens. This makes the per-event credit and billing flow easier to understand and keeps the account UI closer to the actual billing state.

## Changes

- Added an active access window card to the band account page
- Surface the most recent paid show start / expiration / restart count / undo grace state
- Kept the existing subscription and per-event billing controls intact
- Added tests for the new account UX section

## Testing

- npm test -- --run app/band/account/page.test.tsx

Advances billing and account management UX on the project board.